### PR TITLE
chore: can cancel setup_logging when init client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,7 @@ async for file in api.drive.file.action.get_files(get_all=True):
   - `DriveActions.get_folders`
 - `Pagination` クラスが追加されました
   - 基本的にユーザーが使うことは想定されていません
-
+- [@omg-xtao](https://github.com/omg-xtao) can cancel setup_logging when init client.
 
 ## [0.4.3] 2023-04-25
 

--- a/mipac/client.py
+++ b/mipac/client.py
@@ -12,11 +12,12 @@ class Client:
         url: str,
         token: str | None = None,
         *,
-        log_level: LOGING_LEVEL_TYPE = 'INFO',
+        log_level: LOGING_LEVEL_TYPE | None = 'INFO',
         use_version: IMisskeyVersions = 12,
         use_version_autodetect: bool = True
     ) -> None:
-        setup_logging(level=log_level)
+        if log_level is not None:
+            setup_logging(level=log_level)
         config.from_dict(use_version=use_version, use_version_autodetect=use_version_autodetect)
         self.config: Config = config
         self.http: HTTPClient = HTTPClient(url, token)


### PR DESCRIPTION
## Ticket link

# What's Change

can cancel setup_logging when init client

## Checklist

* [x] Read the contribution guide
* [x] (If needed) Update CHANGELOG.md